### PR TITLE
Added @Output events

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,8 @@
             "style": "kebab-case"
           }
         ],
-        "@angular-eslint/no-output-on-prefix": 0
+        "@angular-eslint/no-output-on-prefix": 0,
+        "@angular-eslint/no-output-rename": 0
       }
     },
     {

--- a/src/lib/angular-markdown-editor/angular-markdown-editor.component.ts
+++ b/src/lib/angular-markdown-editor/angular-markdown-editor.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, forwardRef, Inject, Input } from '@angular/core';
+import {AfterViewInit, Component, ElementRef, EventEmitter, forwardRef, Inject, Input, Output} from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { EditorLocale, EditorOption } from './models';
 import { GlobalEditorOptions } from './global-editor-options';
@@ -32,6 +32,18 @@ export class AngularMarkdownEditorComponent implements AfterViewInit {
 
   /** Number of rows for the textarea */
   @Input() rows = 10;
+
+  /** These do not actually ever emit, since bootstrap-markdown already emits the event. This is simply just for typings **/
+  @Output('onShow') private readonly _onShow: EventEmitter<any> = new EventEmitter<any>();
+  @Output('onPreview') private readonly _onPreview: EventEmitter<any> = new EventEmitter<any>();
+  @Output('onPreviewEnd') private readonly _onPreviewEnd: EventEmitter<any> = new EventEmitter<any>();
+  @Output('onSave') private readonly _onSave: EventEmitter<any> = new EventEmitter<any>();
+  @Output('onBlur') private readonly _onBlur: EventEmitter<any> = new EventEmitter<any>();
+  @Output('onFocus') private readonly _onFocus: EventEmitter<any> = new EventEmitter<any>();
+  @Output('onChange') private readonly _onChange: EventEmitter<any> = new EventEmitter<any>();
+  @Output('onFullscreen') private readonly _onFullscreen: EventEmitter<any> = new EventEmitter<any>();
+  @Output('onFullscreenExit') private readonly _onFullscreenExit: EventEmitter<any> = new EventEmitter<any>();
+  @Output('onSelect') private readonly _onSelect: EventEmitter<any> = new EventEmitter<any>();
 
   public value: any | any[];
   public onModelChange: Function = () => { };


### PR DESCRIPTION
- Added @Output decorator for all events so they will be recognized in angular html templates.
- The EventEmitters will never actually emit any events though, since bootstrap-markdown is already emitting events, we can't use the EventEmitters or else the events will get fired twice.
- I chose to make all the event emitters private just in case someone ever used @ViewChild or @ViewChildren and tried to access them and found that they don't actually do anything.